### PR TITLE
edit jupytext github action to preserve cell ids

### DIFF
--- a/.github/workflows/build-notebooks.yaml
+++ b/.github/workflows/build-notebooks.yaml
@@ -19,13 +19,13 @@ jobs:
           python -m pip install -U pip
           python -m pip install jupytext nbconvert
 
-
       - name: Build notebooks
         run: |
-          jupytext --to ipynb --update-metadata '{"jupytext":{"cell_metadata_filter":"all"}}' solution.py
+          jupytext --to ipynb --update-metadata '{"jupytext":{"cell_metadata_filter":"all"}}' --update solution.py
+          jupytext --to ipynb --update-metadata '{"jupytext":{"cell_metadata_filter":"all"}}' --update solution.py --output exercise.ipynb
 
-          jupyter nbconvert solution.ipynb --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_cell_tags solution --to notebook --output exercise.ipynb
-          jupyter nbconvert solution.ipynb --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_cell_tags task --to notebook --output solution.ipynb
+          jupyter nbconvert solution.ipynb --ClearOutputPreprocessor.enabled=True --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_cell_tags task --to notebook --output solution.ipynb
+          jupyter nbconvert exercise.ipynb --ClearOutputPreprocessor.enabled=True --TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_cell_tags solution --to notebook --output exercise.ipynb
 
       - uses: EndBug/add-and-commit@v9
         with:


### PR DESCRIPTION
I was playing around with the gh action and I think I found a way to preserve the cell ids which means there's no changes to the notebooks if the solution.py file hasn't changed and then the commit is avoided.

More specifically, the --update flag for jupytext preserves the cell id but also the output. So I instead remove the outputs with the nbconvert.

Haven't tested it super thorougly but e.g. this commit https://github.com/dlmbl/unet/commit/4e917edbab85ade5ee5e42351af65bd9a9f65a4f was not followed by a ghaction commit
